### PR TITLE
build: adapt to itcoin-core changes (v23.2 -> v24.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(itcoin-fbft
     HOMEPAGE_URL https://github.com/bancaditalia/itcoin-fbft.git
     DESCRIPTION "A prototype FBFT implementation for itcoin"
 )
-set(PROJECT_VERSION "0.1.0")
+set(PROJECT_VERSION "0.2.0")
 set(${PROJECT_NAME}_VERSION ${PROJECT_VERSION})
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -233,10 +233,10 @@ set(ITCOIN_CORE_LIBRARIES
     ${ITCOIN_CORE_SRC_DIR}/src/libbitcoin_common.a
     ${ITCOIN_CORE_SRC_DIR}/src/libbitcoin_consensus.a
     ${ITCOIN_CORE_SRC_DIR}/src/libbitcoin_util.a
-    ${ITCOIN_CORE_SRC_DIR}/src/crypto/libbitcoin_crypto_base.a
-    ${ITCOIN_CORE_SRC_DIR}/src/crypto/libbitcoin_crypto_avx2.a
-    ${ITCOIN_CORE_SRC_DIR}/src/crypto/libbitcoin_crypto_x86_shani.a
-    ${ITCOIN_CORE_SRC_DIR}/src/crypto/libbitcoin_crypto_sse41.a
+    ${ITCOIN_CORE_SRC_DIR}/src/crypto/.libs/libbitcoin_crypto_base.a
+    ${ITCOIN_CORE_SRC_DIR}/src/crypto/.libs/libbitcoin_crypto_avx2.a
+    ${ITCOIN_CORE_SRC_DIR}/src/crypto/.libs/libbitcoin_crypto_x86_shani.a
+    ${ITCOIN_CORE_SRC_DIR}/src/crypto/.libs/libbitcoin_crypto_sse41.a
     ${ITCOIN_CORE_SRC_DIR}/src/.libs/libunivalue.a
     ${ITCOIN_CORE_SRC_DIR}/src/secp256k1/.libs/libsecp256k1.a
 )


### PR DESCRIPTION
During the transition itcoin-core v23.2 -> v24.1 (https://github.com/bancaditalia/itcoin-core/pull/8) the location of some static libraries changed and the build broke.
This commit adapts the cmake scripts.

Because of this, the itcoin-fbft version is incremented from **v0.1.0** to **v0.2.0**.

The impacted libraries are:
- `libbitcoin_crypto_base.a`
- `libbitcoin_crypto_avx2.a`
- `libbitcoin_crypto_x86_shani.a`
- `libbitcoin_crypto_sse41.a`

They were moved from `<base>/src/crypto/` to `<base>/src/crypto/.libs`.
